### PR TITLE
idler/selector: simplify init

### DIFF
--- a/src/modules/idler.cpp
+++ b/src/modules/idler.cpp
@@ -155,6 +155,7 @@ bool Idler::Step() {
         return false;
     case Ready:
         if (!homingValid && mg::globals.FilamentLoaded() < mg::InFSensor) {
+            // home the Idler only in case we don't have filament loaded in the printer (or at least we think we don't)
             PlanHome();
             return false;
         }
@@ -166,14 +167,8 @@ bool Idler::Step() {
 }
 
 void Idler::Init() {
-    if (mg::globals.FilamentLoaded() < mg::InFSensor) {
-        // home the Idler only in case we don't have filament loaded in the printer (or at least we think we don't)
-        PlanHome();
-    } else {
-        // otherwise assume the Idler is at its idle position (that's where it usually is)
-        mm::motion.SetPosition(mm::Idler, SlotPosition(IdleSlotIndex()).v);
-        InvalidateHoming(); // and plan homing sequence ASAP
-    }
+    // Re-home axis at first opportunity. See 'Ready' state.
+    InvalidateHoming();
 }
 
 } // namespace idler

--- a/src/modules/selector.cpp
+++ b/src/modules/selector.cpp
@@ -122,6 +122,7 @@ bool Selector::Step() {
         return false;
     case Ready:
         if (!homingValid && mg::globals.FilamentLoaded() < mg::InSelector && (!mf::finda.Pressed())) {
+            // home the Selector only in case we don't have filament loaded (or at least we think we don't)
             PlanHome();
             return false;
         }
@@ -133,14 +134,8 @@ bool Selector::Step() {
 }
 
 void Selector::Init() {
-    if (mg::globals.FilamentLoaded() < mg::FilamentLoadState::InSelector && (!mf::finda.Pressed())) {
-        // home the Selector only in case we don't have filament loaded (or at least we think we don't)
-        PlanHome();
-    } else {
-        // otherwise set selector's position according to know slot positions (and pretend it is correct)
-        mm::motion.SetPosition(mm::Selector, SlotPosition(mg::globals.ActiveSlot()).v);
-        InvalidateHoming(); // and plan homing sequence ASAP
-    }
+    // Re-home axis at first opportunity. See 'Ready' state.
+    InvalidateHoming();
 }
 
 } // namespace selector


### PR DESCRIPTION
The homing is always invalidated in all cases. Let's simply invalidate the homing only in the init method. The state machine's Ready state then decides when it is OK to perform the homing move.

We shouldn't need to guess the axis's position, and should assume its not correct. Currently the init methods are only called during the boot up sequence.

Change in memory:
Flash: -126 bytes
SRAM: 0 bytes